### PR TITLE
GitHub info

### DIFF
--- a/skare3_tools/github/github.py
+++ b/skare3_tools/github/github.py
@@ -302,6 +302,7 @@ class Repository:
         self.checks = Checks(self)
         self.pull_requests = PullRequests(self)
         self.merge = Merge(self)
+        self.dispatch_event = DispatchEvent(self)
 
 
 class Releases(_EndpointGroup):
@@ -818,6 +819,13 @@ class Checks(_EndpointGroup):
         return self._get('repos/:owner/:repo/commits/:ref/check-runs',
                          headers={'Accept': 'application/vnd.github.antiope-preview+json'},
                          ref=ref)
+
+class DispatchEvent(_EndpointGroup):
+    def __call__(self, event_type, client_payload={}):
+        params = {'event_type': event_type,
+                  'client_payload': client_payload}
+        return self._post('/repos/:owner/:repo/dispatches',
+                          json=params)
 
 
 class Repositories(_EndpointGroup):


### PR DESCRIPTION
- Added dispatch events to Github API. This is to trigger conda builds from a script.
- Added ska3-dev conda package version
- Changed the way we query conda (get package info, as opposed to dry-run install it)
- Added release_info to result. This includes merges and commits that went into each release. One can choose to keep all releases, the releases after a given release, or a fixed number of releases.
- Added docstring for get_repository_info.

These changes were tested by comparing the output of the script in this branch and in master. It also fixes a few minor issues:
- one package had the wrong number of PRs reported because some happened very close in time as the release (right before)
- a package (skare) was missing in the master version.