### PR TITLE
Updates in docker builder (skare3 branch, skare3 version overwrite)

### DIFF
--- a/actions/build/Dockerfile
+++ b/actions/build/Dockerfile
@@ -1,4 +1,7 @@
 FROM docker.pkg.github.com/sot/skare3/centos5-builder:latest
 
+RUN git config --global user.email 'aca@cfa.harvard.edu'
+RUN git config --global user.name 'ska'
+
 COPY files/build.py /home/ska/build-pkg.py
 ENTRYPOINT ["/home/ska/build-pkg.py"]

--- a/actions/build/files/condarc.in
+++ b/actions/build/files/condarc.in
@@ -1,6 +1,6 @@
 binstar_upload: false
 channels:
-  - https://ska:${CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/dev
+  - https://ska:${CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/masters
   - https://ska:${CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/core-pkg-repo
   - https://ska:${CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda
   - defaults


### PR DESCRIPTION
 - Add the possibility to choose skare3 branch and overwrite ska3-* version.
 - Removed --force option (it can still be passed on the command line)
 - Hiding the temporary git repo inside the docker instance, because now the script commits to its local copy, potentially leaving it in a kind of dirty state.