### PR TITLE
enabling the use of a specific env variable to specify github token

### DIFF
--- a/skare3_tools/github/github.py
+++ b/skare3_tools/github/github.py
@@ -91,6 +91,8 @@ def init(user=None, password=None, token=None):
     if GITHUB_API is None:
         if token is not None:
             api = GithubAPI(token=token)
+        elif 'GITHUB_API_TOKEN' in os.environ:
+            api = GithubAPI(token=os.environ['GITHUB_API_TOKEN'])
         elif 'GITHUB_TOKEN' in os.environ:
             api = GithubAPI(token=os.environ['GITHUB_TOKEN'])
         else:

--- a/skare3_tools/github/graphql.py
+++ b/skare3_tools/github/graphql.py
@@ -177,6 +177,8 @@ def init(token=None):
     if GITHUB_API is None:
         if token is not None:
             api = GithubAPI(token=token)
+        elif 'GITHUB_API_TOKEN' in os.environ:
+            api = GithubAPI(token=os.environ['GITHUB_API_TOKEN'])
         elif 'GITHUB_TOKEN' in os.environ:
             api = GithubAPI(token=os.environ['GITHUB_TOKEN'])
         else:


### PR DESCRIPTION
(different from the standard GITHUB_TOKEN used in workflows, which has only permissions for the current repo)