### PR TITLE
Fix release description so PR links are full URIs

### DIFF
--- a/skare3_tools/github/scripts/release_merge_info.py
+++ b/skare3_tools/github/scripts/release_merge_info.py
@@ -55,6 +55,9 @@ def main():
             'Merge pull request (?P<pr>.+) from (?P<branch>\S+)\n\n(?P<description>.+)', msg)
         if match:
             msg = match.groupdict()
+            if msg["pr"][0] == '#':
+                msg["pr"] = f'[{msg["pr"]}]' \
+                            f'(https://github.com/{args.repository}/pull/{msg["pr"][1:]})'
             merges.append(f'PR {msg["pr"]}: {msg["description"]}')
     if merges:
         # edit the release to include the merge information


### PR DESCRIPTION
Fix release description so PR links are full URIs.

When a release is made, the release description is edited to add the PRs. This description is copied into an issue in the skare3 repository requesting a package update. If the link to the PR is not a full URL, the link in the skare3 issue will not point back to the right PR, but will point to another skare3 issue.

This PR fixes that problem.