### PR TITLE
formatting the output of skare3-promote

### DIFF
--- a/skare3_tools/scripts/skare3_promote.py
+++ b/skare3_tools/scripts/skare3_promote.py
@@ -190,9 +190,9 @@ def parser():
     usage = "%(prog)s [-h] [--ska3-conda SKA3_CONDA] [--from FROM_CHANNEL [--from FROM_CHANNEL ...] ] [--to TO_CHANNEL] [--dry-run] [--move] [--skare3-local-copy SKARE3] [--log-level {error,warning,info,debug}] [-v] <package name>==<version> [<package name>==<version> ...]"
     parse = argparse.ArgumentParser(description=__doc__, usage=usage)
     parse.add_argument('package', nargs='+', metavar='<package name>==<version>')
-    parse.add_argument('--ska3-conda', help="ska3-conda directory containing source and target channels", default=SKA3_CONDA)
-    parse.add_argument('--from', help="source channel", dest='from_channels', action='append')
-    parse.add_argument('--to', help="target channel", dest='to_channel')
+    parse.add_argument('--ska3-conda', help="ska3-conda directory containing source and target channels (defaults to the standard location)", default=SKA3_CONDA)
+    parse.add_argument('--from', help="source channel (default: ['masters', 'test'])", dest='from_channels', action='append')
+    parse.add_argument('--to', help="target channel (default: 'flight')", dest='to_channel')
     parse.add_argument('--dry-run', help="do not copy/move and do not index target conda channel", action='store_true', default=False)
     parse.add_argument('--move', help="move packages instead of copying", action='store_true', default=False)
     parse.add_argument('--skare3-local-copy', help='path to the local copy of the skare3 repo (on a tempdir by default)', dest='skare3')
@@ -225,6 +225,8 @@ def main():
             logging.error(f'"{args.ska3_conda}" does not exist.')
             sys.exit(1)
 
+        logging.info(f'Promoting from: {", ".join(args.from_channels)}')
+        logging.info(f'Promoting to:   {args.to_channel}')
         if not args.skare3.exists():
             repo = git.Repo.clone_from(SKARE3_URL, args.skare3)
         else:


### PR DESCRIPTION
This PR improves the output format of skare3-promote. I might still improve this a bit, but it works.

After this PR is merged, when I do this:
```
skare3-promote --ska3-conda /proj/sot/ska/www/ASPECT_ICXC/ska3-conda --from test  --to flight ska3-core==2021.2 ska3-flight==2021.2
```

I will get this:
```
ska3-core==2021.2
=================
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
| package name                   | noarch                           | linux-64                         | osx-64                           | win-64                           |
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
| astropy                        | ---                      ---     | 4.2                      test    | 4.2                      test    | 4.2                      test    |
| bleach                         | 3.3.0                    test    | ---                      ---     | ---                      ---     | ---                      ---     |
| ca-certificates                | ---                      ---     | 2021.1.19                test    | 2021.1.19                test    | 2021.1.19                test    |
| certifi                        | ---                      ---     | 2020.12.5                test    | 2020.12.5                test    | 2020.12.5                test    |
| krb5                           | ---                      ---     | ---                      ---     | 1.18.2                   test    | 1.18.2                   test    |
| libcurl                        | ---                      ---     | ---                      ---     | 7.71.1                   test    | 7.71.1                   test    |
| libiconv                       | ---                      ---     | 1.15                     test    | ---                      ---     | ---                      ---     |
| libsolv                        | ---                      ---     | 0.7.16                   test    | 0.7.14                   test    | 0.7.17                   test    |
| libssh2                        | ---                      ---     | ---                      ---     | 1.9.0                    test    | 1.9.0                    test    |
| mamba                          | ---                      ---     | 0.5.1                    test    | 0.4.2                    test    | 0.5.1                    test    |
| openssl                        | ---                      ---     | 1.1.1i                   test    | 1.1.1i                   test    | 1.1.1i                   test    |
| plotly                         | 4.14.3                   test    | ---                      ---     | ---                      ---     | ---                      ---     |
| pyerfa                         | ---                      ---     | 1.7.1.1                  test    | 1.7.1.1                  test    | 1.7.1.1                  test    |
| python-kaleido                 | ---                      ---     | 0.0.3                    test    | 0.0.3                    test    | 0.0.3                    test    |
| python_abi                     | ---                      ---     | 3.8                      test    | 3.8                      test    | 3.8                      test    |
| retrying                       | 1.3.3                    test    | ---                      ---     | ---                      ---     | ---                      ---     |
| ska3-core                      | ---                      ---     | 2021.2                   test    | 2021.2                   test    | 2021.2                   test    |
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
ska3-flight==2021.2
===================
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
| package name                   | noarch                           | linux-64                         | osx-64                           | win-64                           |
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
| aca_view                       | ---                      ---     | 0.6.0                    test    | 0.6.0                    test    | 0.6.0                    test    |
| aca_weekly_report              | ---                      ---     | 0.1.5                    test    | 0.1.5                    test    | 0.1.5                    test    |
| acdc                           | ---                      ---     | 4.7.3                    test    | 4.7.3                    test    | 4.7.3                    test    |
| chandra_aca                    | 4.32.0                   test    | ---                      ---     | ---                      ---     | ---                      ---     |
| cxotime                        | 3.2.5                    test    | 3.2.5                    test    | 3.2.5                    test    | 3.2.5                    test    |
| jobwatch                       | ---                      ---     | 0.2.0                    test    | 0.2.0                    test    | 0.2.0                    test    |
| kadi                           | ---                      ---     | 5.5.1                    test    | 5.5.1                    test    | 5.5.1                    test    |
| maude                          | 3.6.0                    test    | ---                      ---     | ---                      ---     | ---                      ---     |
| mica                           | 4.25.0                   test    | ---                      ---     | ---                      ---     | ---                      ---     |
| perigee_health_plots           | ---                      ---     | 0.1.3                    test    | 0.1.3                    test    | 0.1.3                    test    |
| proseco                        | 4.11.1                   test    | ---                      ---     | ---                      ---     | ---                      ---     |
| ska.engarchive                 | ---                      ---     | 4.52.0                   test    | 4.52.0                   test    | 4.52.0                   test    |
| ska3-flight                    | 2021.2                   test    | ---                      ---     | ---                      ---     | ---                      ---     |
| ska_helpers                    | 0.5.0                    test    | ---                      ---     | ---                      ---     | ---                      ---     |
| skare3_tools                   | ---                      ---     | 1.0.3                    test    | 1.0.3                    test    | 1.0.3                    test    |
+--------------------------------+----------------------------------+----------------------------------+----------------------------------+----------------------------------+
```