### PR TITLE
Fix version overwrite when building

### DIFF
--- a/skare3_tools/scripts/build.py
+++ b/skare3_tools/scripts/build.py
@@ -48,6 +48,7 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
         m = re.search(r'(\s+)?version(\s+)?:(\s+)?(?P<version>(\S+)+)', line)
         if m:
             version = m.groupdict()['version']
+            version = version.strip('"').strip("'")
             if version == str(current_version):
                 print(f'    - version: {current_version} -> {new_version}')
                 lines[i] = line.replace(current_version, new_version)


### PR DESCRIPTION
When building meta-package pre-releases (e.g. 2021.10rcN), we overwrite the release version on file (2021.10) to add the `rcN` part.

Unfortunately, the code that does the overwriting reads the file line by line and does not use yaml. And as it turns out... the version needs to be enclosed in quotations so yaml does not interpret 2021.10 as a float (2021.1). These two conflict with each other. Adding quotations breaks the version-overwriting code, which does not expect any quotations.

This fixes that.

# Functional test

The code in this PR produces the desired change in the yaml file:
```
import skare3_tools.scripts.build as build 
from pathlib import Path 
pkg_path = Path('pkg_defs/ska3-matlab') 
build.overwrite_skare3_version('2021.10', '2021.10rc2', pkg_path)  
```