### PR TITLE
change conda channels in default config to what they should be

### DIFF
--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -82,9 +82,8 @@ _DEFAULT_CONFIG = {
     'repository': 'https://github.com/sot/skare3',
     'conda_channels': {
         'masters': ['https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/masters'],
-        'main': ['https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/shiny'],
-        'dull': ['https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda'],
-        "test": ["https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda",
+        'main': ['https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'],
+        "test": ["https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight",
                  "https://ska:{CONDA_PASSWORD}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/test"]
     },
     'organizations': ['sot', 'acisops'],


### PR DESCRIPTION
The current master version creates a config file with the wrong default configuration: it points to older conda channels.

This PR fixes that.