### PR TITLE
Fix: Enable releases with closed PRs

### DIFF
--- a/skare3_tools/scripts/skare3_release_check.py
+++ b/skare3_tools/scripts/skare3_release_check.py
@@ -104,7 +104,10 @@ def main():
             branch_name = ''
             if not fail:
                 branch_name = release['target_commitish']
-                pulls = repository.pull_requests(state='open', head=f'sot:{branch_name}')
+                pulls = repository.pull_requests(
+                    state='open' if release["prerelease"] else 'all',
+                    head=f'sot:{branch_name}'
+                )
                 pulls = [p for p in pulls if p['title'] == branch_name]
                 if branch_name not in allowed_names:
                     fail.append(f'Invalid branch name "{branch_name}" for release "{tag_name}". '


### PR DESCRIPTION
On release workflow, require the existence of an open PR only if it is a prerelease, otherwise accept closed PRs as well.