### PR TITLE
Remove use of --tags option to git

### DIFF
--- a/skare3_tools/scripts/skare3_promote.py
+++ b/skare3_tools/scripts/skare3_promote.py
@@ -82,7 +82,7 @@ def promote(package, args, platforms=None):
     package = m.groupdict()
 
     skare3_repo = git.Repo(args.skare3)
-    skare3_repo.remotes.origin.fetch("--tags")
+    skare3_repo.remotes.origin.fetch()
     meta = None
     if re.match("ska3-", package["name"]):
         try:

--- a/skare3_tools/scripts/skare3_release_check.py
+++ b/skare3_tools/scripts/skare3_release_check.py
@@ -108,7 +108,6 @@ def main():
     # some sanity checks
     fail = []
     if args.ci_sanity_check:
-
         """
         The following checks that:
         - release exists


### PR DESCRIPTION
## Description

This PR introdues changes to skare3_promote.py to remove uses of the `--tags` argument to git. This option does not exist anymore.

Fixes #93 

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
