### PR TITLE
Add module for converting docstrings to numpydoc format

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   lint:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/skare3_tools/github/scripts/add_secrets.py
+++ b/skare3_tools/github/scripts/add_secrets.py
@@ -153,7 +153,7 @@ def add_secrets(repository, secrets):
 
         _driver_.find_element_by_id("secret_name").send_keys(secret)
         value = secrets[secret]
-        if type(value) is dict:
+        if isinstance(value, dict):
             value = json.dumps(value)
         _driver_.find_element_by_id("secret_value").send_keys(value)
 

--- a/skare3_tools/github/scripts/merge_pr.py
+++ b/skare3_tools/github/scripts/merge_pr.py
@@ -46,7 +46,7 @@ def main():
     kwargs["state"] = "open"
     prs = repository.pull_requests(**kwargs)
 
-    if type(prs) is dict and not prs["response"]["ok"]:
+    if isinstance(prs, dict) and not prs["response"]["ok"]:
         print(f'Failed getting requested PR: {prs["response"]["reason"]}')
         sys.exit(1)
 
@@ -57,7 +57,7 @@ def main():
     # sanity checks
     sha = prs[0]["head"]["sha"]
     if args.sha and sha != args.sha:
-        print(f"Requested sha does not match that of the PR")
+        print("Requested sha does not match that of the PR")
         sys.exit(1)
 
     # do the merge

--- a/skare3_tools/scripts/convert_numpydoc.py
+++ b/skare3_tools/scripts/convert_numpydoc.py
@@ -336,9 +336,7 @@ def convert_lines_to_numpydoc(lines):
     """
     lines_out = None
 
-    idx_any = get_first_marker_index(
-        lines, REST_MARKERS_RETURNS + REST_MARKERS_PARAMS
-    )
+    idx_any = get_first_marker_index(lines, REST_MARKERS_RETURNS + REST_MARKERS_PARAMS)
     idx_params = get_first_marker_index(lines, REST_MARKERS_PARAMS)
     idx_returns = get_first_marker_index(lines, REST_MARKERS_RETURNS)
 

--- a/skare3_tools/scripts/convert_numpydoc.py
+++ b/skare3_tools/scripts/convert_numpydoc.py
@@ -1,0 +1,311 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Convert docstrings from reST to numpydoc format."""
+
+import ast
+import re
+from pathlib import Path
+
+REST_MARKERS_RETURNS = [":returns:", ":return:", ":rtype:"]
+REST_MARKERS_PARAMS = [":param "]
+
+
+def get_function_docstrings(module_file: str) -> dict[dict]:
+    """
+    Get the docstring for each function in the given module file.
+
+    Parameters
+    ----------
+    module_file : str
+        The path to the module file.
+
+    Returns
+    -------
+    dict
+        A dictionary of function names and docstring information.
+    """
+    with open(module_file, "r") as f:
+        module_source = f.read()
+
+    module_ast = ast.parse(module_source)
+
+    function_docstrings = []
+
+    function_nodes = []
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef):
+            function_nodes.append(node)
+        elif isinstance(node, ast.ClassDef):
+            for method_node in node.body:
+                if isinstance(method_node, ast.FunctionDef):
+                    function_nodes.append(method_node)
+
+    for node in function_nodes:
+        function_name = node.name
+        function_docstring = ast.get_docstring(node, clean=False)
+        if function_docstring:
+            function_docstrings.append(
+                {
+                    "name": function_name,
+                    "text": function_docstring,
+                    "idx_func_start": node.lineno - 1,
+                    "idx_func_stop": node.end_lineno - 1,
+                }
+            )
+
+    return function_docstrings
+
+
+def find_quote_style(lines: list):
+    """Find the quote style used for a docstring.
+
+    This assumes that the lines are part of a function definition and that
+    the docstring is the first thing in the function definition.
+    """
+    for line in lines:
+        for quotes in ['"""', "'''"]:
+            if quotes in line:
+                return quotes
+
+
+def get_docstring_blocks(module_file) -> list[dict]:
+    """Get all the docstrings that look like reST format in the list of lines.
+
+    Returns a list of dict with keys:
+    - ``idx0``: (int) Index of start of docstring text
+    - ``idx1``: (int) Index of end of docstring text
+    - ``lines``: (list) Lines of docstring
+
+    :param lines: list
+        List of Python code lines.
+    :returns: list of dict
+    """
+    docstrings_ast = get_function_docstrings(module_file)
+    lines = Path(module_file).read_text().splitlines()
+
+    docstring_blocks = []
+
+    # for function_name, docstring_ast in docstrings_ast.items():
+    for docstring_ast in docstrings_ast:
+        # Skip functions without any reST markers in the docstring
+        if not any(
+            marker in docstring_ast["text"]
+            for marker in REST_MARKERS_RETURNS + REST_MARKERS_PARAMS
+        ):
+            continue
+
+        idx0 = None
+        idx1 = None
+
+        # Line range for this function including docstring
+        idx0_func = docstring_ast["idx_func_start"]
+        idx1_func = docstring_ast["idx_func_stop"]
+
+        quotes = find_quote_style(lines[idx0_func:idx1_func])
+
+        for idx in range(idx0_func, idx1_func):
+            line = lines[idx].strip()
+            if re.match(f"^{quotes}.*{quotes}$", line):
+                idx0 = idx
+                idx1 = idx + 1
+                break
+            if idx0 is None and line.startswith(quotes):
+                idx0 = idx
+            elif idx0 is not None and line.endswith(quotes):
+                if line.strip() != quotes:
+                    raise ValueError(
+                        f"docstring {quotes} must be on separate line\n"
+                        f"line: {line}\n"
+                        f"line number: {idx + 1}\n"
+                    )
+                # Don't include final quotes in this processing
+                idx1 = idx
+                break
+
+        if idx0 is not None and idx1 is not None:
+            lines_out = lines[idx0:idx1]
+            indent = len(lines_out[0]) - len(lines_out[0].lstrip())
+            lines_out = [line[indent:] for line in lines_out]
+
+            docstring_block = {
+                # "function_name": function_name,
+                "idx0": idx0,
+                "idx1": idx1,
+                "indent": indent,
+                "lines": lines_out,
+            }
+            docstring_blocks.append(docstring_block)
+
+    return docstring_blocks
+
+
+def get_first_marker_index(lines, markers):
+    for idx, line in enumerate(lines):
+        if any(line.startswith(marker) for marker in markers):
+            return idx
+    else:
+        return len(lines)
+
+
+def get_marker_idxs(lines: list[str], markers_rest: list[str]):
+    # Get line indexes in lines where a reST marker is found
+    idxs = []
+    markers = []
+    for idx, line in enumerate(lines):
+        for marker in markers_rest:
+            if line.startswith(marker):
+                idxs.append(idx)
+                markers.append(marker)
+                break
+    idxs.append(len(lines))
+    return idxs, markers
+
+
+def params_to_numpydoc(lines):
+    if not lines:
+        return []
+
+    idxs, _ = get_marker_idxs(lines, [":param "])
+    lines_out = [
+        "Parameters",
+        "----------",
+    ]
+
+    for idx0, idx1 in zip(idxs[:-1], idxs[1:]):
+        lines_param = lines[idx0:idx1]
+        line_param = lines_param[0]
+        match = re.match(r":param \s+ (\w+) \s* : \s* (.*)", line_param, re.VERBOSE)
+        if match:
+            name = match.group(1)
+            desc = match.group(2)
+        else:
+            raise ValueError(f"Could not parse line: {line_param}")
+
+        if idx1 - idx0 == 1:
+            # Single line param, no type(s) given
+            lines_out.append(name)
+            lines_out.append("    " + desc.strip())
+        else:
+            # Multiline, so assume the first line is the type(s)
+            lines_out.append(f"{name} : {desc}")
+            for line in lines_param[1:]:
+                lines_out.append("    " + line.strip())
+
+    return lines_out
+
+
+def returns_to_numpydoc(lines):
+    if not lines:
+        return []
+
+    idxs, markers = get_marker_idxs(lines, REST_MARKERS_RETURNS)
+
+    return_type = None
+    return_desc_lines = []
+
+    for idx0, idx1, marker in zip(idxs[:-1], idxs[1:], markers):
+        if marker == ":rtype:":
+            return_type = " ".join(lines[idx0:idx1])
+            return_type = return_type[len(marker) :].strip()
+
+        elif marker in [":return:", ":returns:"]:
+            return_desc_lines = [lines[idx0][len(marker) :]] + lines[idx0 + 1 : idx1]
+
+    lines_out = [
+        "Returns",
+        "-------",
+    ]
+
+    if return_type is None:
+        # No explicit return type so just use the description.
+        prefix = ""
+    else:
+        lines_out.append(return_type)
+        prefix = "    "
+
+    for line in return_desc_lines:
+        lines_out.append(prefix + line.strip())
+
+    return lines_out
+
+
+def convert_lines_to_numpydoc(lines):
+    """Convert docstring lines to numpydoc format.
+
+    :param lines: list
+        List of lines of docstring text.
+    :returns: list
+        List of lines of docstring text in numpydoc format.
+    """
+    lines_out = None
+
+    idx_any = get_first_marker_index(
+        lines, [":param ", ":returns:", ":rtype:", ":return:"]
+    )
+    idx_params = get_first_marker_index(lines, [":param "])
+    idx_returns = get_first_marker_index(lines, [":returns:", ":rtype:", ":return:"])
+
+    lines_out = lines[:idx_any]
+    # Cut lines_out at the end if they are blank
+    while lines_out[-1].strip() == "":
+        lines_out = lines_out[:-1]
+
+    lines_params = [line for line in lines[idx_params:idx_returns] if line.strip()]
+    lines_returns = [line for line in lines[idx_returns:] if line.strip()]
+
+    lines_params_out = params_to_numpydoc(lines_params)
+    lines_returns_out = returns_to_numpydoc(lines_returns)
+
+    if lines_params_out:
+        lines_out.append("")
+        lines_out.extend(lines_params_out)
+
+    if lines_returns_out:
+        lines_out.append("")
+        lines_out.extend(lines_returns_out)
+
+    return lines_out, lines_params, lines_returns
+
+
+def indent_lines(lines, indent):
+    out_lines = []
+    for line in lines:
+        if line:
+            out_lines.append(indent + line)
+        else:
+            out_lines.append(line)
+    return out_lines
+
+
+def convert_module_to_numpydoc(module_file_in, module_file_out):
+    """Convert module docstrings to numpydoc format.
+
+    :param module_file: str
+        Path to module file.
+    :returns: list
+        List of lines of docstring text in numpydoc format.
+    """
+    lines = Path(module_file_in).read_text().splitlines()
+    lines_orig = lines.copy()
+
+    docstring_blocks = get_docstring_blocks(module_file_in)
+
+    for docstring_block in reversed(docstring_blocks):
+        idx0 = docstring_block["idx0"]
+        idx1 = docstring_block["idx1"]
+        lines_out, _, _ = convert_lines_to_numpydoc(docstring_block["lines"])
+        lines_out = indent_lines(lines_out, " " * docstring_block["indent"])
+        lines = lines[:idx0] + lines_out + lines[idx1:]
+
+    if module_file_in == module_file_out and lines == lines_orig:
+        # Don't bother rewriting unchanged file
+        return
+
+    print(f"Writing {module_file_out}")
+    file_end = "\n" if lines else ""
+    Path(module_file_out).write_text("\n".join(lines) + file_end)
+
+
+def convert_directory_to_numpydoc(dir_file):
+    """Walk through a directory and convert all docstrings to numpydoc format."""
+    for path in Path(dir_file).glob("**/*.py"):
+        convert_module_to_numpydoc(path, path)


### PR DESCRIPTION
## Description

This provides a module (and eventually a command line script) to convert from [ReST format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html) docstrings to [numpydocs](https://numpydoc.readthedocs.io/en/latest/example.html) format. 

I spent some time trying to use the `pyment` package but found that it does not handle any docstring with inline examples. After an hour trying to make that package work I bailed. In the end some customization was useful -- we have used non-standard conventions in docstrings over the years and this code tries to do the best with what's there.

The ReST format which is used in most Ska packages is unsatisfactory because it does not really support indicating the type of input parameters. It is also a bit tired and doesn't look nice.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
See https://github.com/sot/chandra_aca/pull/156 and rendered output in the description.