### PR TITLE
Package dashboard fixes

### DIFF
--- a/skare3_tools/github/graphql.py
+++ b/skare3_tools/github/graphql.py
@@ -263,6 +263,9 @@ REPO_QUERY = """
         number
         title
         url
+        mergeCommit {
+            oid
+        }
         commits(last: 100) {
           totalCount
           nodes {

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -347,7 +347,7 @@ _COMPARE_COMMITS_QUERY = """
       compare(headRef: "{{ head }}") {
         aheadBy
         behindBy
-        commits(first: 100, after: "{{ after }}") {
+        commits(first: 100, after: "{{ cursor }}") {
           nodes {
             oid
             message
@@ -443,6 +443,9 @@ def get_all_nodes(
     if query_2 is None:
         query_2 = query
     while data[path]["pageInfo"][has_more]:
+        if at == data[path]["pageInfo"][cursor]:
+            raise RuntimeError('Cursor did not change and will cause an infinite loop')
+
         at = data[path]["pageInfo"][cursor]
         data = Dict(
             github.GITHUB_API_V4(

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -518,25 +518,29 @@ def _get_repository_info_v4(
 
     commits_path = "data/repository/defaultBranchRef/target/history"
     commits = data_v4[commits_path]["nodes"]
-    commits += get_all_nodes(
-        owner,
-        name,
-        commits_path,
-        _COMMIT_QUERY,
-        reverse=False,
-        at=data_v4[commits_path]["pageInfo"]["endCursor"],
-    )
+    if data_v4[commits_path]["pageInfo"]["endCursor"] is not None:
+        # append the rest of the commits only if there were commits to begin with
+        commits += get_all_nodes(
+            owner,
+            name,
+            commits_path,
+            _COMMIT_QUERY,
+            reverse=False,
+            at=data_v4[commits_path]["pageInfo"]["endCursor"],
+        )
 
     pull_requests_path = "data/repository/pullRequests"
     pull_requests = data_v4[pull_requests_path]["nodes"]
-    pull_requests += get_all_nodes(
-        owner,
-        name,
-        pull_requests_path,
-        _PR_QUERY,
-        reverse=True,
-        at=data_v4[pull_requests_path]["pageInfo"]["startCursor"],
-    )
+    if data_v4[pull_requests_path]["pageInfo"]["startCursor"] is not None:
+        # append the rest of the PRs only if there were commits to begin with
+        pull_requests += get_all_nodes(
+            owner,
+            name,
+            pull_requests_path,
+            _PR_QUERY,
+            reverse=True,
+            at=data_v4[pull_requests_path]["pageInfo"]["startCursor"],
+        )
 
     # from now, keep a list of the open pull requests on the main branch
     all_pull_requests = {pr["number"]: pr for pr in pull_requests}

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -447,7 +447,7 @@ def get_all_nodes(
         query_2 = query
     while data[path]["pageInfo"][has_more]:
         if at == data[path]["pageInfo"][cursor]:
-            raise RuntimeError('Cursor did not change and will cause an infinite loop')
+            raise RuntimeError("Cursor did not change and will cause an infinite loop")
 
         at = data[path]["pageInfo"][cursor]
         data = Dict(


### PR DESCRIPTION
## Description

Fixes for dashboard:
- Properly identify commits for squashed merges (#105).
- repositories with no releases were crashing.
- repositories with no PRs or no commits were crashing.
- fix an issue causing an infinite loop when fetching a list of commits.
- remove `use_pr_titles` argument (which was never`False` anyway)

Fixes #105 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This is the version currently running in the dashboard. You can see starcheck 32 and agasc 161, which are squashed PRs.
