### PR TITLE
Improve sharing of skare3_tools data between users

### DIFF
--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -124,7 +124,9 @@ def init(config=None, reset=False):
     app_data_dir = _app_data_dir_()
     if app_data_dir is None:
         raise Exception(
-            "Could not figure out where to place skare3_tools configuration"
+            "Could not figure out the location of the skare3_tools configuration.\n"
+            "Either create the $SKA/data/skare3/skare3_data directory\n"
+            "or set the SKARE3_TOOLS_DATA environmental variable."
         )
     config_file = os.path.join(app_data_dir, "config.json")
     exists = os.path.exists(config_file)

--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -9,6 +9,7 @@ standard password to conda channels called CONDA_PASSWORD.
 The configuration is saved in JSON format, in the location:
 
 - specified by the SKARE3_TOOLS_DATA environmental variable,
+- or in the directory $SKA/data/skare3/skare3_data
 - or:
 
   - Linux/Mac OS: ~/.skare3
@@ -106,8 +107,11 @@ _DEFAULT_CONFIG = {
 def _app_data_dir_():
     local_app_data_dir = os.getenv("LOCALAPPDATA")
     home_dir = os.path.expanduser("~")
+    ska_data_dir = os.path.join(os.environ["SKA"], "data", "skare3", "skare3_data")
     if "SKARE3_TOOLS_DATA" in os.environ:
         app_data_dir = os.environ["SKARE3_TOOLS_DATA"]
+    elif os.path.exists(ska_data_dir):
+        app_data_dir = ska_data_dir
     elif local_app_data_dir:
         # this is the windows location
         app_data_dir = os.path.join(local_app_data_dir, "skare3")

--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -10,10 +10,6 @@ The configuration is saved in JSON format, in the location:
 
 - specified by the SKARE3_TOOLS_DATA environmental variable,
 - or in the directory $SKA/data/skare3/skare3_data
-- or:
-
-  - Linux/Mac OS: ~/.skare3
-  - windows: %LOCALAPPDATA%\\skare3
 
 The default looks like this:
 
@@ -105,19 +101,11 @@ _DEFAULT_CONFIG = {
 
 
 def _app_data_dir_():
-    local_app_data_dir = os.getenv("LOCALAPPDATA")
-    home_dir = os.path.expanduser("~")
     ska_data_dir = os.path.join(os.environ["SKA"], "data", "skare3", "skare3_data")
     if "SKARE3_TOOLS_DATA" in os.environ:
         app_data_dir = os.environ["SKARE3_TOOLS_DATA"]
     elif os.path.exists(ska_data_dir):
         app_data_dir = ska_data_dir
-    elif local_app_data_dir:
-        # this is the windows location
-        app_data_dir = os.path.join(local_app_data_dir, "skare3")
-    elif os.path.exists(home_dir) and os.access(home_dir, os.W_OK):
-        # can use this in linux and Mac OS
-        app_data_dir = os.path.join(home_dir, ".skare3")
     else:
         app_data_dir = None
     return app_data_dir

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -1036,13 +1036,13 @@ def repository_info_is_outdated(_, pkg_info):
     Cache update policy that returns True if the Github repository has been updated or pushed into.
 
     If the calling user has not write access to the cache directory, this function returns False,
-    unless SKARE3_REPO_INFO_UPDATE is set to "True".
+    unless SKARE3_REPO_INFO_LATEST is set to "True".
 
     :param _:
     :param pkg_info: dict. As returned from :func:`~skare3_tools.packages.get_repository_info`.
     :return:
     """
-    update = os.environ.get("SKARE3_REPO_INFO_UPDATE", "").lower() in ["true", "1"]
+    update = os.environ.get("SKARE3_REPO_INFO_LATEST", "").lower() in ["true", "1"]
     if not dir_access_ok(CONFIG["data_dir"]) and not update:
         return False
     result = github.GITHUB_API_V4(_LAST_UPDATED_QUERY.render(**pkg_info))

--- a/skare3_tools/test_results.py
+++ b/skare3_tools/test_results.py
@@ -233,6 +233,12 @@ def add(directory, stream, tags=(), properties={}):
     with open(INDEX_FILE, "w") as f:
         json.dump(test_result_index, f, indent=2)
 
+    # update the symbolic link pointing to the latest test in the stream
+    symlink = SKARE3_TEST_DATA / stream
+
+    symlink.unlink(missing_ok=True)
+    symlink.symlink_to(abs_destination)
+
 
 def _ignore_unreadable(src, names):
     # this is used in shutil.copytree to ignore files that are not readable due to permissions

--- a/skare3_tools/test_results.py
+++ b/skare3_tools/test_results.py
@@ -28,26 +28,90 @@ import hashlib
 import json
 import os
 import shutil
+import tempfile
+import logging
+
+from pathlib import Path
+from cxotime import CxoTime, units as u
+from tqdm import tqdm
+from skare3_tools.config import CONFIG
 
 
 class TestResultException(Exception):
     pass
 
 
-from skare3_tools.config import CONFIG
+SKARE3_TEST_DATA = Path(CONFIG["data_dir"]).absolute() / "test_logs"
+INDEX_FILE = SKARE3_TEST_DATA / "index.json"
 
-SKARE3_DASH_DATA = CONFIG["data_dir"]
+if not SKARE3_TEST_DATA.exists():
+    SKARE3_TEST_DATA.mkdir(parents=True)
 
-if not os.path.exists(SKARE3_DASH_DATA):
-    os.makedirs(os.path.join(SKARE3_DASH_DATA, "test_logs"))
-
-INDEX_FILE = os.path.join(SKARE3_DASH_DATA, "test_logs", "index.json")
-if not os.path.exists(os.path.dirname(INDEX_FILE)):
-    os.makedirs(os.path.dirname(INDEX_FILE))
-if not os.path.exists(INDEX_FILE):
+if not INDEX_FILE.exists():
     with open(INDEX_FILE, "w") as f:
         f.write("[]")
     del f
+
+
+LOGGER = logging.getLogger("skare3_tools")
+
+
+def remove(uid=None, directory=None, uids=(), directories=()):
+    with open(INDEX_FILE, "r") as fh:
+        test_result_index = json.load(fh)
+
+    uids = list(uids)
+    if uid and uid not in uids:
+        uids += [uid]
+
+    directories = [SKARE3_TEST_DATA / directory for directory in directories]
+    if directory and directory not in directories:
+        directories += [SKARE3_TEST_DATA / directory]
+
+    # make sure all directories are absolute and within the data tree
+    for directory in directories:
+        if SKARE3_TEST_DATA not in directory.resolve().parents:
+            LOGGER.warning(f"warning: {directory} not in SKARE3_DASH_DATA. Ignoring")
+    directories = [
+        directory for directory in directories if SKARE3_TEST_DATA in directory.resolve().parents
+    ]
+
+    # make a list of everything that will be removed
+    rm = [
+        tr for tr in test_result_index
+        if tr["uid"] in uids
+        or SKARE3_TEST_DATA / tr["destination"] in directories
+    ]
+
+    for tr in rm:
+        test_result_index.remove(tr)
+        shutil.rmtree(SKARE3_TEST_DATA / tr["destination"])
+
+    for directory in directories:
+        if directory.exists():
+            LOGGER.warning(
+                f"The directory {directory} is still there."
+                "This does not happen unless the directory is already not in the index,"
+                "in which case it is safe to remove it by hand."
+                )
+
+    with open(INDEX_FILE, "w") as fh:
+        json.dump(test_result_index, fh, indent=2)
+
+
+def remove_older_than(days):
+    with open(INDEX_FILE, "r") as fh:
+        test_result_index = json.load(fh)
+
+    for tr in test_result_index:
+        all_test_log = SKARE3_TEST_DATA / tr["destination"] / "all_tests.json"
+        with open(all_test_log) as fh:
+            test_suites = json.load(fh)
+            date = CxoTime(test_suites["run_info"]["date"])
+            rm = []
+            if date < CxoTime() - days * u.day:
+                rm.append(tr["uid"])
+            remove(uids=rm)
 
 
 def add(directory, stream, tags=(), properties={}):
@@ -61,13 +125,14 @@ def add(directory, stream, tags=(), properties={}):
         Other properties to store about this test suite.
     :return:
     """
-    if not os.path.exists(directory):
+    directory = Path(directory)
+    if not directory.exists():
         raise TestResultException(
             'Directory "{directory}" does not exist'.format(directory=directory)
         )
 
-    all_test_log = os.path.join(directory, "all_tests.json")
-    if not os.path.exists(all_test_log):
+    all_test_log = directory / "all_tests.json"
+    if not all_test_log.exists():
         raise TestResultException(
             "Not importing: all_tests.json not found in {directory}".format(
                 directory=directory
@@ -83,14 +148,18 @@ def add(directory, stream, tags=(), properties={}):
     if uid in [r["uid"] for r in test_result_index]:
         raise TestResultException("These test results already exist")
 
-    all_test_log = os.path.join(directory, "all_tests.json")
+    all_test_log = directory / "all_tests.json"
     with open(all_test_log) as f:
         test_suites = json.load(f)
 
     date = test_suites["run_info"]["date"]
     destination = "{stream}_{date}_{uid}".format(stream=stream, date=date, uid=uid)
-    abs_destination = os.path.join(SKARE3_DASH_DATA, "test_logs", destination)
+    abs_destination = SKARE3_TEST_DATA / destination
+    if abs_destination.exists():
+        raise Exception(f"Destination already exists: {abs_destination}")
 
+    # architecture, system, hostname and platform are stored as lists in the testr output file
+    # and this "fixes that", at the expense of changing the format.
     test_suites["run_info"]["system"] = " ".join(test_suites["run_info"]["system"])
     test_suites["run_info"]["architecture"] = " ".join(
         test_suites["run_info"]["architecture"]
@@ -140,17 +209,39 @@ def add(directory, stream, tags=(), properties={}):
     )
     test_result_index.append(result)
 
-    shutil.copytree(directory, abs_destination)
+    # copying to a temporary directory first, to make sure there are no surprises
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_destination = Path(tmpdirname) / destination
+        shutil.copytree(
+            directory,
+            tmp_destination,
+            ignore=_ignore_unreadable
+        )
+        shutil.copy(
+            all_test_log,
+            tmp_destination / (all_test_log.name + '.orig')
+        )
+        with open(tmp_destination / all_test_log.name , "w") as f:
+            json.dump(test_suites, f, indent=2)
+
+        # after that succeeded, copy to the final destination (which does not exist yet)
+        shutil.copytree(
+            tmp_destination,
+            abs_destination,
+        )
+
     with open(INDEX_FILE, "w") as f:
         json.dump(test_result_index, f, indent=2)
 
-    with open(os.path.join(abs_destination, os.path.basename(all_test_log)), "w") as f:
-        json.dump(test_suites, f, indent=2)
+
+def _ignore_unreadable(src, names):
+    # this is used in shutil.copytree to ignore files that are not readable due to permissions
+    return [name for name in names if not os.access(os.path.join(src, name), os.R_OK)]
 
 
 def get(stream=None, architecture=None, tag=None, system=None):
     """
-    Get the all test results for the given stream, architecture, tag and system.
+    Get all the test results for the given stream, architecture, tag and system sorted by date.
 
     :param stream: str
     :param architecture: str
@@ -171,9 +262,7 @@ def get(stream=None, architecture=None, tag=None, system=None):
         ):
             continue
         directory = tr["destination"]
-        all_test_log = os.path.join(
-            SKARE3_DASH_DATA, "test_logs", directory, "all_tests.json"
-        )
+        all_test_log = SKARE3_TEST_DATA / directory / "all_tests.json"
         with open(all_test_log) as f:
             test_suites = json.load(f)
             if "run_info" not in test_suites:
@@ -196,6 +285,15 @@ def get_latest(stream=None, architecture=None, tag=None, system=None):
     test_results = get(stream=stream, architecture=architecture, tag=tag, system=system)
     test_results = test_results[-1] if len(test_results) else {}
     return test_results
+
+
+def streams():
+    """
+    Get available streams.
+    """
+    with open(INDEX_FILE, "r") as f:
+        test_result_index = json.load(f)
+    return set([tr["stream"] for tr in test_result_index])
 
 
 def parser():
@@ -224,7 +322,7 @@ def main():
     try:
         add(args.directory, stream=args.stream)
     except TestResultException as e:
-        print("Error:", e)
+        LOGGER.error("Error:", e)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Description

The changes in this PR allow the `kadi` user to take over weekly processing. These changes include:
- moving the skare3_tools data into `$SKA/data`.
- making sure the caching decorators do not fail if the user has no write access to skare3_tools data.
- removing the option of having skare3_tools data in `~/skare3` (Linux and OSX) or ` %LOCALAPPDATA%\\skare3` (Windows). I decided we will never use it. We will always use `$SKA/data/`, and if we really need to change that, we can define `SKARE3_TOOLS_DATA`.
- added a few book-keeping functions for storing test results.
- replacing some uses of `os.path` by `pathlib`.

Please don't pay attention to linter. I made another PR that will come after this and fix linting (#108).

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

After this PR any user will be able to use the skare3_tools installed on HEAD to get the package information. All data will be stored in `$SKA/data/skare3` or in `$SKARE3_TOOLS_DATA`. This includes test result data as well as cached package data.

If the cache is old, and the user does not have write access to the cache directory, the old information in the cache is returned, unless `SKARE3_REPO_INFO_LATEST=true`, in which case the latest info is returned but the cache is not updated.


## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
This branch is installed by hand in the ska3-masters environment owned by kadi and the dashboard and testing has used it.

Anyone should be able to do the following and get reasonable-looking result:
```
from skare3_tools import packages, config, test_results

assert config.CONFIG['data_dir'] == f'{os.environ["SKA"]}/data/skare3/skare3_data/data'

pkgs = packages.get_package_list()
pkgs_info = packages.get_repositories_info()
tr = test_results.get(stream='ska3-masters')
```

On HEAD, it should use the data that the kadi user has put in `/proj/sot/ska`. If you want to use your own location, you can set the `SKARE3_TOOLS_DATA` environment variable, and in this case
```
config.CONFIG['data_dir'] == os.path.join(os.environ["SKARE3_TOOLS_DATA"], 'data')
```

