### PR TITLE
Replace most uses of os.path with pathlib

### DIFF
--- a/skare3_tools/dashboard/views/test_log.py
+++ b/skare3_tools/dashboard/views/test_log.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 import re
 
 from skare3_tools import config, dashboard
@@ -90,13 +89,13 @@ def test_log(path):
         return dashboard.get_template("error.html").render(
             title="404 Error", message="Run {run_id} not found".format(run_id=run_id)
         )
-    filename = os.path.join(
-        config.CONFIG["data_dir"],
-        "test_logs",
-        test_runs[0]["run_info"]["destination"],
-        filename,
+    filename = (
+        config.CONFIG["data_dir"]
+        / "test_logs"
+        / test_runs[0]["run_info"]["destination"]
+        / filename
     )
-    if not os.path.exists(filename) or not os.path.isfile(filename):
+    if not filename.exists() or not filename.is_file():
         return dashboard.get_template("error.html").render(
             title="404 Error", message="File {path} not found".format(path=path)
         )

--- a/skare3_tools/github/scripts/add_secrets.py
+++ b/skare3_tools/github/scripts/add_secrets.py
@@ -32,6 +32,7 @@ import logging
 import os
 import sys
 import time
+from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
@@ -163,7 +164,10 @@ def parser():
     parse = argparse.ArgumentParser(description=__doc__)
     parse.add_argument("repositories", nargs="+")
     parse.add_argument(
-        "--secrets", default="secrets.json", help="JSON file with all secrets"
+        "--secrets",
+        default="secrets.json",
+        help="JSON file with all secrets",
+        type=Path,
     )
     parse.add_argument("--user", required=True, help="Github user name")
     parse.add_argument(
@@ -190,7 +194,7 @@ def main():
         )
         the_parser.exit(2)
 
-    if not os.path.exists(args.secrets):
+    if not args.secrets.exists():
         logging.error(
             f"The secrets file {args.secrets} does not exist. "
             f"Run `{sys.argv[0]} -h` for help."

--- a/skare3_tools/scripts/skare3_release_check.py
+++ b/skare3_tools/scripts/skare3_release_check.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import sys
+from pathlib import Path
 
 import git
 import jinja2
@@ -39,7 +40,7 @@ def parser():
     parse = argparse.ArgumentParser(description=__doc__)
     parse.add_argument("--version", required=True, help="Target version to build")
     parse.add_argument(
-        "--skare3-path", default=".", help="local copy of the skare3 repo"
+        "--skare3-path", default=".", help="local copy of the skare3 repo", type=Path
     )
     parse.add_argument(
         "--repository", default="sot/skare3", help="Github repository name"
@@ -68,7 +69,7 @@ def log(msg, level=logging.ERROR):
 def main():
     arg_parser = parser()
     args = arg_parser.parse_args()
-    args.skare3_path = os.path.abspath(args.skare3_path)
+    args.skare3_path = args.skare3_path.resolve()
 
     git_repo = None
     try:
@@ -188,7 +189,7 @@ def main():
 
     # checking package versions
     # whenever a version equals `branch_name`, replace it by the full version.
-    files = glob.glob(os.path.join(args.skare3_path, "pkg_defs", "ska3-*", "meta.yaml"))
+    files = glob.glob(args.skare3_path / "pkg_defs" / "ska3-*" / "meta.yaml")
     packages = []
     possible_error = []
     version_str = str(version_info["final_version"])

--- a/skare3_tools/scripts/test_results.py
+++ b/skare3_tools/scripts/test_results.py
@@ -6,12 +6,12 @@ Deprecated Script: Gather test results from testr's log file.
 import argparse
 import importlib
 import json
-import os
 import re
+from pathlib import Path
 
 
 def test_results(directory):
-    filename = os.path.join(directory, "test.log")
+    filename = directory / "test.log"
     with open(filename) as f:
         for line in f:
             if re.match(r"\*\*\*\s+Package\s+Script\s+Status\s+\*\*\*", line):
@@ -35,7 +35,7 @@ def test_results(directory):
             result_dict[k[0]]["version"] = version
 
             test_results = {
-                "log_directory": os.path.basename(directory),
+                "log_directory": directory.name,
                 "results": result_dict,
             }
     return test_results
@@ -47,11 +47,13 @@ def parser():
         "directory",
         help="Directory containing all test results."
         "It must contain a file named test.log",
+        type=Path,
     )
     parse.add_argument(
         "-o",
         help="Output file name (default: test_results.json)",
         default="test_results.json",
+        type=Path,
     )
     return parse
 

--- a/skare3_tools/test_results.py
+++ b/skare3_tools/test_results.py
@@ -66,7 +66,7 @@ def remove(uid=None, directory=None, uids=(), directories=()):
     if uid and uid not in uids:
         uids += [uid]
 
-    directories = [SKARE3_TEST_DATA / directory for directory in directories]
+    directories = [SKARE3_TEST_DATA / drctry for drctry in directories]
     if directory and directory not in directories:
         directories += [SKARE3_TEST_DATA / directory]
 


### PR DESCRIPTION
## Description

This should introduce no changes. It just replaces uses of `os.path` with `pathlib`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
