### PR TITLE
allow skare3_tools config in the HOME directory

### DIFF
--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -12,6 +12,10 @@ The configuration is saved in JSON format, in the location:
 
 - specified by the SKARE3_TOOLS_DATA environmental variable,
 - or in the directory $SKA/data/skare3/skare3_data
+- or:
+
+  - Linux/Mac OS: ~/.skare3
+  - windows: %LOCALAPPDATA%\\skare3
 
 The default looks like this:
 
@@ -103,11 +107,21 @@ _DEFAULT_CONFIG = {
 
 
 def _app_data_dir_():
-    ska_data_dir = os.path.join(os.environ["SKA"], "data", "skare3", "skare3_data")
+    home_dir = os.path.expanduser("~")
     if "SKARE3_TOOLS_DATA" in os.environ:
         app_data_dir = os.environ["SKARE3_TOOLS_DATA"]
-    elif os.path.exists(ska_data_dir):
+    elif (
+        "SKA" in os.environ
+        and (ska_data_dir := os.path.join(os.environ["SKA"], "data", "skare3", "skare3_data"))
+        and os.path.exists(ska_data_dir)
+    ):
         app_data_dir = ska_data_dir
+    elif local_app_data_dir := os.getenv("LOCALAPPDATA"):
+        # this is the windows location
+        app_data_dir = os.path.join(local_app_data_dir, "skare3")
+    elif os.path.exists(home_dir) and os.access(home_dir, os.W_OK):
+        # can use this in linux and Mac OS
+        app_data_dir = os.path.join(home_dir, ".skare3")
     else:
         app_data_dir = None
     return app_data_dir

--- a/skare3_tools/config.py
+++ b/skare3_tools/config.py
@@ -112,7 +112,11 @@ def _app_data_dir_():
         app_data_dir = os.environ["SKARE3_TOOLS_DATA"]
     elif (
         "SKA" in os.environ
-        and (ska_data_dir := os.path.join(os.environ["SKA"], "data", "skare3", "skare3_data"))
+        and (
+            ska_data_dir := os.path.join(
+                os.environ["SKA"], "data", "skare3", "skare3_data"
+            )
+        )
         and os.path.exists(ska_data_dir)
     ):
         app_data_dir = ska_data_dir


### PR DESCRIPTION
This reinstates the possibility of having the config directory in the home directory. I removed this in #107 to make things simple, but it turns out that some use cases do not have SKA available, and I would have to go around checking these to add `SKARE3_TOOLS_DATA`.

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
I unset `SKA` and successfully ran 
```
skare3-release-merge-info --repository sot/skare3_tools --sha a0a8338d6f48c22121fec79aa73de9051c57ab32 --stdout
```
I verified that this created `~/.skare3`. I removed it after all tests, so this doesn't cause me trouble in the future.

also in python:
```
In [1]: from skare3_tools import config

In [2]: config.CONFIG['data_dir']
Out[2]: '/Users/javierg/.skare3/data'
```

and I repeated this last step defining `SKARE3_TOOLS_DATA`, both with and without `SKA`
