### PR TITLE
In get_conda_pkg_info: do not have subprocess.run check the return code.

### DIFF
--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -785,8 +785,7 @@ def get_conda_pkg_info(conda_package, conda_channel=None):
         msg += " -".join(unreachable)
         raise NetworkException(msg)
 
-    check = kwargs.pop("check", True)
-    p = subprocess.run(cmd, check=check, **kwargs)
+    p = subprocess.run(cmd, check=False, **kwargs)
     out = json.loads(p.stdout.decode())
     if (
         "error" in out


### PR DESCRIPTION
This fixes some unwanted output, and fixes `packages.get_conda_pkg_info` so it works for github repositories that do not have a corresponding package with the same name.

The code was searching for a conda package named the same way as the repo, which is trivially not true in repos that have no package at all.

This is a trivial change. Basically, the `check` argument passed to `subprocess.run` was popped from a kwargs variable that was local and never had the `check` key, so it was always being set to `True`. Also, `check=True`  was obviously not the original intent of this code, since right after the call to `subprocess.run` the output was being parsed and inspected for errors, optionally ignoring them in exactly the cases we care about.

This affects nothing we care about. After the PR, there will be package info for these repos, but we do not care about them.

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests

Ran the update dashboard script and there was no unwanted output.
