### PR TITLE
Small Fixes

### DIFF
--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -167,21 +167,18 @@ def json_cache(name, directory="", ignore=None, expires=None, update_policy=None
             if update_policy is not None and result is not None:
                 update = update or update_policy(filename, result)
             if not dir_access_ok(filename):
-                if result is None:
-                    raise Exception(
-                        f"No write access to cache file {filename} and no cached value"
-                    )
                 logging.getLogger("skare3").debug(
                     f"No write access to cache file {filename}"
                 )
                 update = False
             if result is None or update:
                 result = func(*args, **kwargs)
-                directory_out = os.path.dirname(filename)
-                if not os.path.exists(directory_out):
-                    os.makedirs(directory_out)
-                with open(filename, "w") as file:
-                    json.dump(result, file)
+                if update:
+                    directory_out = os.path.dirname(filename)
+                    if not os.path.exists(directory_out):
+                        os.makedirs(directory_out)
+                    with open(filename, "w") as file:
+                        json.dump(result, file)
             return result
 
         def clear_cache():

--- a/skare3_tools/scripts/skare3_release_check.py
+++ b/skare3_tools/scripts/skare3_release_check.py
@@ -80,7 +80,7 @@ def main():
     ]  # versions can be git refs like refs/tags/V2
     # regular expression (mostly) matching PEP-0440 version format
     fmt = (
-        r"(?P<final_version>((?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(.[0-9]+(.[0-9]+)?)?))"
+        r"(?P<final_version>((?P<epoch>[0-9]+)!)?(?P<release>[0-9]+(\.[0-9]+(\.[0-9]+)?)?))"
         r"((a|b|rc)(?P<rc>[0-9]+))?(\+(?P<label>[a-zA-Z]+))?$"
     )
     version_info = re.match(fmt, tag_name)

--- a/skare3_tools/scripts/skare3_update_summary.py
+++ b/skare3_tools/scripts/skare3_update_summary.py
@@ -27,7 +27,16 @@ class ArgumentException(Exception):
 
 class CondaException(Exception):
     def __init__(self, info):
-        super().__init__(info["message"])
+        if "message" in info:
+            msg = info["message"]
+        elif "error" in info:
+            msg = info["error"]
+            trace = [line for line in info.get("traceback", []).split("\n") if line]
+            msg += "\n"
+            msg += trace[-1]
+        else:
+            msg = "Unknown error"
+        super().__init__(msg)
         self.info = info
 
 


### PR DESCRIPTION
## Description

This PR fixes an issue when using `skare3_tools.packages` after the package data was moved to `$SKA/data` owned by kadi. Before this PR, if the user had no permission to write in the cache directory, and there is no cache data for that repo, an exception would be raised. After this, if the user has no permission to write to the cache directory, the cache directory is never written to.

There are also small improvements to error messages in skare3_update_summary

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
