### PR TITLE
Add osx-arm64 to build handler

### DIFF
--- a/skare3_tools/scripts/build.py
+++ b/skare3_tools/scripts/build.py
@@ -217,7 +217,7 @@ def main():
         build_dir = pathlib.Path("builds")
         if not build_dir.exists():
             build_dir.mkdir()
-        for d in ["linux-64", "osx-64", "noarch", "win-64"]:
+        for d in ["linux-64", "osx-64", "osx-arm64", "noarch", "win-64"]:
             print(d)
             d_from = skare3_path / "builds" / d
             d_to = build_dir / d
@@ -239,6 +239,7 @@ def main():
         files = (
             list(build_dir.glob("linux-64/*tar.bz2*"))
             + list(build_dir.glob("osx-64/*tar.bz2*"))
+            + list(build_dir.glob("osx-arm64/*tar.bz2*"))
             + list(build_dir.glob("noarch/*tar.bz2*"))
             + list(build_dir.glob("win-64/*tar.bz2*"))
         )


### PR DESCRIPTION
## Description

Add osx-arm64 to build handler

I think this will help to get osx-arm64 saved in the github action.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
I haven't tested this.  I was hoping to just test by running it out of master and I don't see where this could hurt anything.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
