### PR TITLE
Update skare3-promote to handle osx-arm64 packages

### DIFF
--- a/skare3_tools/scripts/skare3_promote.py
+++ b/skare3_tools/scripts/skare3_promote.py
@@ -30,9 +30,10 @@ SKA3_CONDA = "/proj/sot/ska/www/ASPECT_ICXC/ska3-conda"
 TO_CHANNEL = "flight"
 FROM_CHANNELS = ["test", "masters"]
 PLATFORM_OPTIONS = {
-    "linux-64": {"linux": True, "linux64": True},
-    "osx-64": {"osx": True, "osx64": True},
-    "win-64": {"win": True, "win64": True},
+    "linux-64": {"linux": True, "linux64": True, "arm64": False},
+    "osx-64": {"osx": True, "osx64": True, "arm64": False},
+    "osx-arm64": {"osx": True, "osx64": True, "arm64": True},
+    "win-64": {"win": True, "win64": True, "arm64": False},
 }
 SECTIONS = ["run"]
 
@@ -122,7 +123,6 @@ def promote(package, args, platforms=None):
                 f" not found for platform {platform}."
             )
             continue
-
         if pkgs is not None:
             package_names += [package["name"]]
             pkg_files += pkgs
@@ -137,7 +137,7 @@ def promote(package, args, platforms=None):
                     r"(?P<name>\S+)(\s+)?(==(\s+)?(?P<version>\S+))?", requirement_str
                 )
                 if match:
-                    requirement = m.groupdict()
+                    requirement = match.groupdict()
 
                     pkgs = _files_to_copy(
                         requirement,
@@ -146,6 +146,7 @@ def promote(package, args, platforms=None):
                         args.to_channel,
                         args.from_channels,
                     )
+
                     if pkgs is not None:
                         if requirement["name"] not in package_names:
                             package_names.append(requirement["name"])
@@ -178,11 +179,12 @@ def promote(package, args, platforms=None):
         "| {noarch:24s} {noarch-src:7s} "
         "| {linux-64:24s} {linux-64-src:7s} "
         "| {osx-64:24s} {osx-64-src:7s} "
+        "| {osx-arm64:24s} {osx-arm64-src:7s} "
         "| {win-64:24s} {win-64-src:7s} |"
     )
-    div = {"package": "", "noarch": "", "linux-64": "", "osx-64": "", "win-64": ""}
+    div = {"package": "", "noarch": "", "linux-64": "", "osx-64": "", "osx-arm64": "", "win-64": ""}
     div.update(
-        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "win-64-src"]}
+        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "osx-arm64-src", "win-64-src"]}
     )
     div = row.format(**div).replace(" ", "-").replace("|", "+")
     header = {
@@ -190,10 +192,11 @@ def promote(package, args, platforms=None):
         "noarch": "noarch",
         "linux-64": "linux-64",
         "osx-64": "osx-64",
+        "osx-arm64": "osx-arm64",
         "win-64": "win-64",
     }
     header.update(
-        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "win-64-src"]}
+        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "osx-arm64-src", "win-64-src"]}
     )
     header = row.format(**header)
     logging.info(div)
@@ -206,10 +209,12 @@ def promote(package, args, platforms=None):
                 "noarch",
                 "linux-64",
                 "osx-64",
+                "osx-arm64",
                 "win-64",
                 "noarch-src",
                 "linux-64-src",
                 "osx-64-src",
+                "osx-arm64-src",
                 "win-64-src",
             ]
         }

--- a/skare3_tools/scripts/skare3_promote.py
+++ b/skare3_tools/scripts/skare3_promote.py
@@ -182,9 +182,25 @@ def promote(package, args, platforms=None):
         "| {osx-arm64:24s} {osx-arm64-src:7s} "
         "| {win-64:24s} {win-64-src:7s} |"
     )
-    div = {"package": "", "noarch": "", "linux-64": "", "osx-64": "", "osx-arm64": "", "win-64": ""}
+    div = {
+        "package": "",
+        "noarch": "",
+        "linux-64": "",
+        "osx-64": "",
+        "osx-arm64": "",
+        "win-64": "",
+    }
     div.update(
-        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "osx-arm64-src", "win-64-src"]}
+        {
+            k: ""
+            for k in [
+                "noarch-src",
+                "linux-64-src",
+                "osx-64-src",
+                "osx-arm64-src",
+                "win-64-src",
+            ]
+        }
     )
     div = row.format(**div).replace(" ", "-").replace("|", "+")
     header = {
@@ -196,7 +212,16 @@ def promote(package, args, platforms=None):
         "win-64": "win-64",
     }
     header.update(
-        {k: "" for k in ["noarch-src", "linux-64-src", "osx-64-src", "osx-arm64-src", "win-64-src"]}
+        {
+            k: ""
+            for k in [
+                "noarch-src",
+                "linux-64-src",
+                "osx-64-src",
+                "osx-arm64-src",
+                "win-64-src",
+            ]
+        }
     )
     header = row.format(**header)
     logging.info(div)

--- a/skare3_tools/test_results.py
+++ b/skare3_tools/test_results.py
@@ -71,11 +71,11 @@ def remove(uid=None, directory=None, uids=(), directories=()):
         directories += [SKARE3_TEST_DATA / directory]
 
     # make sure all directories are absolute and within the data tree
-    for direct in directories:
-        if SKARE3_TEST_DATA not in direct.resolve().parents:
-            LOGGER.warning(f"warning: {direct} not in SKARE3_DASH_DATA. Ignoring")
+    for drctry in directories:
+        if SKARE3_TEST_DATA not in drctry.resolve().parents:
+            LOGGER.warning(f"warning: {drctry} not in SKARE3_DASH_DATA. Ignoring")
     directories = [
-        direct for direct in directories if SKARE3_TEST_DATA in direct.resolve().parents
+        drctry for drctry in directories if SKARE3_TEST_DATA in drctry.resolve().parents
     ]
 
     # make a list of everything that will be removed
@@ -89,10 +89,10 @@ def remove(uid=None, directory=None, uids=(), directories=()):
         test_result_index.remove(tr)
         shutil.rmtree(SKARE3_TEST_DATA / tr["destination"])
 
-    for direct in directories:
-        if direct.exists():
+    for drctry in directories:
+        if drctry.exists():
             LOGGER.warning(
-                f"The directory {direct} is still there."
+                f"The directory {drctry} is still there."
                 "This does not happen unless the directory is already not in the index,"
                 "in which case it is safe to remove it by hand."
             )


### PR DESCRIPTION
## Description

Adds osx-arm64 to platforms to promote.

I just used this to promote packages to the test channel using PYTHONPATH.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This was live-tested to promote ska3-perl 2024.7.
