### PR TITLE
Fix dashboard

### DIFF
--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -245,9 +245,15 @@ def _conda_package_list(update=True):
     for f in all_meta:
         macro = "{% macro compiler(arg) %}{% endmacro %}\n"
         macro += "{% macro pin_compatible(arg) %}{% endmacro %}\n"
-        info = yaml.load(
-            jinja2.Template(macro + open(f).read()).render(environ={}), Loader=yaml.FullLoader
-        )
+        try:
+            info = yaml.load(
+                jinja2.Template(macro + open(f).read()).render(environ={}), Loader=yaml.FullLoader
+            )
+        except jinja2.TemplateError as err:
+            parent = os.path.split(os.path.split(f)[-2])[-1]
+            logging.getLogger("skare3").error(f"Failed to parse recipe for {parent}: {err}")
+            continue
+
         pkg_info = {
             "name": os.path.basename(os.path.dirname(f)),
             "package": info["package"]["name"],

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -244,8 +244,9 @@ def _conda_package_list(update=True):
     all_info = []
     for f in all_meta:
         macro = "{% macro compiler(arg) %}{% endmacro %}\n"
+        macro += "{% macro pin_compatible(arg) %}{% endmacro %}\n"
         info = yaml.load(
-            jinja2.Template(macro + open(f).read()).render(), Loader=yaml.FullLoader
+            jinja2.Template(macro + open(f).read()).render(environ={}), Loader=yaml.FullLoader
         )
         pkg_info = {
             "name": os.path.basename(os.path.dirname(f)),

--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -247,11 +247,14 @@ def _conda_package_list(update=True):
         macro += "{% macro pin_compatible(arg) %}{% endmacro %}\n"
         try:
             info = yaml.load(
-                jinja2.Template(macro + open(f).read()).render(environ={}), Loader=yaml.FullLoader
+                jinja2.Template(macro + open(f).read()).render(environ={}),
+                Loader=yaml.FullLoader,
             )
         except jinja2.TemplateError as err:
             parent = os.path.split(os.path.split(f)[-2])[-1]
-            logging.getLogger("skare3").error(f"Failed to parse recipe for {parent}: {err}")
+            logging.getLogger("skare3").error(
+                f"Failed to parse recipe for {parent}: {err}"
+            )
             continue
 
         pkg_info = {

--- a/skare3_tools/test_results.py
+++ b/skare3_tools/test_results.py
@@ -71,13 +71,11 @@ def remove(uid=None, directory=None, uids=(), directories=()):
         directories += [SKARE3_TEST_DATA / directory]
 
     # make sure all directories are absolute and within the data tree
-    for directory in directories:
-        if SKARE3_TEST_DATA not in directory.resolve().parents:
-            LOGGER.warning(f"warning: {directory} not in SKARE3_DASH_DATA. Ignoring")
+    for direct in directories:
+        if SKARE3_TEST_DATA not in direct.resolve().parents:
+            LOGGER.warning(f"warning: {direct} not in SKARE3_DASH_DATA. Ignoring")
     directories = [
-        directory
-        for directory in directories
-        if SKARE3_TEST_DATA in directory.resolve().parents
+        direct for direct in directories if SKARE3_TEST_DATA in direct.resolve().parents
     ]
 
     # make a list of everything that will be removed
@@ -91,10 +89,10 @@ def remove(uid=None, directory=None, uids=(), directories=()):
         test_result_index.remove(tr)
         shutil.rmtree(SKARE3_TEST_DATA / tr["destination"])
 
-    for directory in directories:
-        if directory.exists():
+    for direct in directories:
+        if direct.exists():
             LOGGER.warning(
-                f"The directory {directory} is still there."
+                f"The directory {direct} is still there."
                 "This does not happen unless the directory is already not in the index,"
                 "in which case it is safe to remove it by hand."
             )


### PR DESCRIPTION
## Description

The package dashboard generation currently fails. The error in the logs is:
```
jinja2.exceptions.UndefinedError: 'environ' is undefined
```

I traced that to the sherpa conda recipe, which includes the following:
```
  version: {{ environ.get('SHERPA_TAG') }}
```
and
```
  run:
    - {{ pin_compatible('numpy') }}
```

This PR includes changes to handle these, and also a try/except clause to skip the package if there is another jinja error.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests



### Functional tests

I used this branch to manually generate the dashboard.

I also commented out [line 247](https://github.com/sot/skare3_tools/pull/116/files#diff-4203511b369325947496331c16d0e0e54dc91a3027d0e281dfcb18dd5c8b5756R247) to verify that the following code does not crash and produces the error message for sherpa:
```
In [1]: from skare3_tools import packages
   ...: pkgs = packages.get_package_list()
Failed to parse recipe for sherpa: 'pin_compatible' is undefined
```
