### PR TITLE
Remove set-output

### DIFF
--- a/skare3_tools/scripts/build.py
+++ b/skare3_tools/scripts/build.py
@@ -246,7 +246,19 @@ def main():
         files = " ".join([str(f) for f in files])
 
         print(f"Built files: {files}")
-        print(f"::set-output name=files::{files}")
+
+        # this output defines variables 'files'
+        if "GITHUB_OUTPUT" in os.environ:
+            mode = "r+" if os.path.exists(os.environ["GITHUB_OUTPUT"]) else "w"
+            with open(os.environ["GITHUB_OUTPUT"], mode) as fh:
+                fh.write(f"files={files}\n")
+
+        # this output will show up in the workflow summary
+        if "GITHUB_STEP_SUMMARY" in os.environ:
+            mode = "r+" if os.path.exists(os.environ["GITHUB_STEP_SUMMARY"]) else "w"
+            with open(os.environ["GITHUB_STEP_SUMMARY"], mode) as fh:
+                for filename in files:
+                    fh.write(f"- {filename}")
 
 
 if __name__ == "__main__":

--- a/skare3_tools/scripts/skare3_release_check.py
+++ b/skare3_tools/scripts/skare3_release_check.py
@@ -206,7 +206,10 @@ def main():
             version_pkg = str(data["package"]["version"])
             if version_str == version_pkg:
                 packages.append(data["package"]["name"])
-            try:
+            elif (
+                version_str != version_float
+                and version_float == version_pkg
+            ):
                 # versions like 2024.10 are "tricky" because if you interpret them as floats
                 # you get a different value. A typical error in meta.yaml is to write
                 #    version: 2024.10
@@ -214,17 +217,9 @@ def main():
                 #    version: "2024.10"
                 # causing the version to be interpreted as 2024.1
                 # and because this does not match the target version, the package is not built.
-                if (
-                    version_str != version_pkg
-                    and version_str != version_float
-                    and version_float == version_pkg
-                ):
-                    # however, we can't know for sure that this is an error
-                    # (e.g. ska3-core 2024.1 and ska3-flight 2024.10 is possible)
-                    possible_error.append(data["package"]["name"])
-            except Exception:
-                # we do nothing if the version can't be interpreted as a float
-                pass
+                # however, we can't know for sure that this is an error
+                # (e.g. ska3-core 2024.1 and ska3-flight 2024.10 is possible)
+                possible_error.append(data["package"]["name"])
 
     if possible_error:
         msg = (


### PR DESCRIPTION

## Description

This PR improves scripts/skare3_release_check.py and scripts/build.py to display a summary in the workflow page, stop using deprecated `::set-output` (sot/skare3/issues/962), and improve the output.

Removing uses of `::set-output` is important because it will stop working at some point, and breaking this script will break all skare3 releases.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing

I still do not know how to test this. The "proper" way might be to create a fork of skare3 and try releases there. I have run it locally with the current 2025.0-branch in skare3.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
