### PR TITLE
add PR chains to dashboard

### DIFF
--- a/skare3_tools/packages.py
+++ b/skare3_tools/packages.py
@@ -590,12 +590,23 @@ def _get_repository_info_v4(
 
     # from now, keep a list of the open pull requests on the main branch
     all_pull_requests = {pr["number"]: pr for pr in pull_requests}
-    pull_requests = [
-        pr
-        for pr in pull_requests
-        if pr["state"] not in ["CLOSED", "MERGED"]
-        and pr["baseRefName"] == default_branch
+
+    outstanding_pulls = [
+        pr for pr in pull_requests if pr["state"] not in ["CLOSED", "MERGED"]
     ]
+
+    pull_requests = []
+    while extra_pr := [
+        pr
+        for pr in outstanding_pulls
+        if pr["number"] not in [p["number"] for p in pull_requests]
+        and (
+            pr["baseRefName"] == default_branch
+            or pr["baseRefName"] in [p["headRefName"] for p in pull_requests]
+        )
+    ]:
+        pull_requests += extra_pr
+
     pull_requests = [
         {
             "number": pr["number"],


### PR DESCRIPTION
## Description

This PR makes changes so chains of PRs are shown in the dashboard. This is not a hard requirement, but I was confused when I saw missing PRs in the dashboard. They were missing because their head was not the main branch, but instead were based on a branch that was the head of another open PR.

The implementation is to iteratively add PRs to the list. A PR is added if its base is the main branch or if its base is already in the list of PRs. The iteration stops when there are no PRs that would be added. There might be a more efficient way to do this, but it works. 

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #119

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Running the following displays the currently open PRs in the two repositories that currently have missing PRs in the dashboard:
```python
In [1]: from skare3_tools import packages, github

In [2]: info_new = packages._get_repository_info_v4("sot/maude")

In [3]: info_new["pull_requests"]
Out[3]: 
[{'number': 52,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/maude/pull/52',
  'title': 'WIP: Add asyncio functions to get blobs and msids',
  'n_commits': 4,
  'last_commit_date': None},
 {'number': 51,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/maude/pull/51',
  'title': 'WIP: Add asyncio function to get frames',
  'n_commits': 4,
  'last_commit_date': None}]

In [4]: info_new = packages._get_repository_info_v4("sot/aca_view")

In [5]: info_new["pull_requests"]
Out[5]: 
[{'number': 208,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/208',
  'title': 'WIP: Use asyncio instead of multiprocess for fetching data',
  'n_commits': 2,
  'last_commit_date': None},
 {'number': 207,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/207',
  'title': 'Rename YAG/ZAG -> AOACYAN/AOACZAN',
  'n_commits': 2,
  'last_commit_date': None},
 {'number': 206,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/206',
  'title': 'Ruff',
  'n_commits': 4,
  'last_commit_date': None},
 {'number': 205,
  'author': 'Tom Aldcroft',
  'url': 'https://github.com/sot/aca_view/pull/205',
  'title': 'Factor out command line start stop obsid handling',
  'n_commits': 8,
  'last_commit_date': None},
 {'number': 197,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/197',
  'title': 'add aperoll',
  'n_commits': 9,
  'last_commit_date': None},
 {'number': 196,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/196',
  'title': 'Set observed mags using chandra_aca.mag_subtract',
  'n_commits': 4,
  'last_commit_date': None},
 {'number': 182,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/182',
  'title': 'WIP: modify docs/conf.py for numpy-style docstrings',
  'n_commits': 5,
  'last_commit_date': None},
 {'number': 159,
  'author': 'Javier Gonzalez',
  'url': 'https://github.com/sot/aca_view/pull/159',
  'title': 'Improve Data dialog',
  'n_commits': 2,
  'last_commit_date': None}]
```
