### PR TITLE
remove use of pkg_resources

### DIFF
--- a/skare3_tools/__init__.py
+++ b/skare3_tools/__init__.py
@@ -1,17 +1,3 @@
-import warnings
+import ska_helpers
 
-from pkg_resources import DistributionNotFound, get_distribution
-from setuptools_scm import get_version
-
-try:
-    try:
-        _dist_info = get_distribution(__name__)
-        __version__ = _dist_info.version
-        # the following fails with a local repo with an egg in it
-        assert __file__.lower().startswith(_dist_info.location.lower())
-    except (DistributionNotFound, AssertionError):
-        # this might be a local git repo
-        __version__ = get_version(root="..", relative_to=__file__)
-except Exception:
-    warnings.warn("Failed to find skare3_tools package version, setting to 0.0.0")
-    __version__ = "0.0.0"
+__version__ = ska_helpers.get_version(__package__)


### PR DESCRIPTION
## Description

This fixes an error that just started appearing due to missing `pkg_resources` package. The change is trivial: just use ska_helpers version

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
