### PR TITLE
go back to not using ska_helpers

### DIFF
--- a/skare3_tools/__init__.py
+++ b/skare3_tools/__init__.py
@@ -1,3 +1,43 @@
-import ska_helpers
+def _get_version():
+    import importlib
+    import logging
+    import pathlib
+    import warnings
 
-__version__ = ska_helpers.get_version(__package__)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message=r"Module \w+ was already imported", category=UserWarning
+        )
+        from importlib import resources, metadata  # noqa: I001
+
+    # Get module file for package.
+    package = "skare3_tools"
+    module_file = importlib.util.find_spec(package).origin
+
+    try:
+        # If resources.files(package) appears to be a git repo, then
+        # importlib has gotten a "local" distribution and the
+        # version just corresponds to whatever version was the
+        # last run of "setup.py sdist" or "setup.py bdist_wheel", i.e.
+        # unrelated to current version, so use setuptools_scm instead.
+        git_dir = resources.files(package).parent / ".git"
+        if git_dir.exists() and git_dir.is_dir():
+            # importing this here so we do not get a failure if setuptools_scm is not installed
+            # and we are not in a git repo
+            import setuptools_scm
+            version = setuptools_scm.get_version(
+                root=pathlib.Path(".."), relative_to=module_file
+            )
+        else:
+            version = metadata.version(package)
+
+
+    except Exception as exc:
+        logging.warning(f"Failed to get version for skare3_tools: {exc}")
+        version = "0.0.0"
+
+
+    return version
+
+
+__version__ = _get_version()

--- a/skare3_tools/__init__.py
+++ b/skare3_tools/__init__.py
@@ -1,3 +1,5 @@
+# we do not use ska_helpers.get_version, because skare3_tools is often used in CI workflows where
+# ska_helpers is not available, so this is a simplified version of that function.
 def _get_version():
     import importlib
     import logging

--- a/skare3_tools/__init__.py
+++ b/skare3_tools/__init__.py
@@ -27,17 +27,16 @@ def _get_version():
             # importing this here so we do not get a failure if setuptools_scm is not installed
             # and we are not in a git repo
             import setuptools_scm
+
             version = setuptools_scm.get_version(
                 root=pathlib.Path(".."), relative_to=module_file
             )
         else:
             version = metadata.version(package)
 
-
     except Exception as exc:
         logging.warning(f"Failed to get version for skare3_tools: {exc}")
         version = "0.0.0"
-
 
     return version
 


### PR DESCRIPTION
## Description

This changes `skare3_tools.__version__` back to not use ska_helpers. Using ska_helpers means we have to install ska_helpers in several workflows, and we do not have an easy way to do that. Setting up conda just for this is too much. We could get the ska_helpers repo directly, but I prefer to just change the `get_version` function.

This uses a simplified version of `ska_helpers.get_version`, basically ignoring cases where the package is not skare3_tools, where it is not a top-level module, where the package has a different name from the module and so on. The only exception where the version is set to `0.0.0` is if one uses skare3_tools from the repo and setuptools_scm is not installed. In most cases this would not be an issue, but anyway it is simple to just install setuptools_scm, as it is included in requirement.txt (e.g.: https://github.com/sot/skare3/blob/master/.github/workflows/package_release.yml#L36)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I created a conda environment with pip:
```
conda create -y -n skare3-tools pip
conda activate skare3-tools 
```
then while in the local repo, I ran the following (expected output in parenthesis):
```bash
# from repo, no setuptools_scm (0.0.0)
python -c "import skare3_tools; print(skare3_tools.__version__)"
pip install setuptools_scm > /dev/null 
# from repo with setuptools_scm (1.7.1.dev7+g6758049dd)
python -c "import skare3_tools; print(skare3_tools.__version__)"
# from repo using PYTHONPATH.   (1.7.1.dev7+g6758049dd)
export PYTHONPATH=`pwd`
cd
python -c "import skare3_tools; print(skare3_tools.__version__)"
cd - > /dev/null
# using pip-installed version (1.7.1.dev7+g6758049dd)
pip install . > /dev/null
cd
python -c "import skare3_tools; print(skare3_tools.__version__)"                                      
cd - > /dev/null
# using the local (dirty) repo while there is an installed version (1.7.1.dev7+g6758049dd.d20260210)
echo >> README.md 
python -c "import skare3_tools; print(skare3_tools.__version__)"
export PYTHONPATH=`pwd`
cd
# using the local (dirty) repo using PYTHONPATH while there is an installed version (1.7.1.dev7+g6758049dd.d20260210)
python -c "import skare3_tools; print(skare3_tools.__version__)"
```

and the output was as expected:
```
WARNING:root:Failed to get version for skare3_tools: No module named 'setuptools_scm'
0.0.0
1.7.1.dev7+g6758049dd
1.7.1.dev7+g6758049dd
1.7.1.dev7+g6758049dd
1.7.1.dev7+g6758049dd.d20260210
1.7.1.dev7+g6758049dd.d20260210
```
